### PR TITLE
Fix pointer cancel on drag zoom

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -103,6 +103,7 @@ const InteractiveTick: React.FC<InteractiveTickProps> = ({
   axisInteraction,
   axisType,
 }) => {
+  const DRAG_REVERT_THRESHOLD = 5; // pixels
   const pointers = React.useRef(new Map<number, { x: number; y: number }>());
   const pinchStartDistance = React.useRef<number>(0);
   // This ref holds the state of a single-pointer pan gesture, immune to re-renders.
@@ -110,6 +111,7 @@ const InteractiveTick: React.FC<InteractiveTickProps> = ({
     id: number;
     lastX: number;
     lastY: number;
+    totalDelta: number;
   } | null>(null);
 
   const handlePointerMove = (e: PointerEvent) => {
@@ -127,12 +129,14 @@ const InteractiveTick: React.FC<InteractiveTickProps> = ({
           axisType === 'x'
             ? e.clientX - panSession.current.lastX
             : e.clientY - panSession.current.lastY;
-        
-        axisInteraction?.handleAxisPan?.(axisType, delta);
-        
-        // CRITICAL: Update the last position for the next movement calculation.
-        panSession.current.lastX = e.clientX;
-        panSession.current.lastY = e.clientY;
+
+        if (Math.abs(delta) > 0) {
+          axisInteraction?.handleAxisPan?.(axisType, delta);
+          panSession.current.totalDelta += delta;
+          // CRITICAL: Update the last position for the next movement calculation.
+          panSession.current.lastX = e.clientX;
+          panSession.current.lastY = e.clientY;
+        }
       }
     }
     // B. Two-pointer pinch-to-zoom (touch-only)
@@ -158,6 +162,9 @@ const InteractiveTick: React.FC<InteractiveTickProps> = ({
     pointers.current.delete(e.pointerId);
     
     if (panSession.current && panSession.current.id === e.pointerId) {
+      if (Math.abs(panSession.current.totalDelta) < DRAG_REVERT_THRESHOLD) {
+        axisInteraction?.handleAxisPan?.(axisType, -panSession.current.totalDelta);
+      }
       panSession.current = null;
     }
 
@@ -168,6 +175,7 @@ const InteractiveTick: React.FC<InteractiveTickProps> = ({
       panSession.current = null;
       window.removeEventListener('pointermove', handlePointerMove, { capture: true });
       window.removeEventListener('pointerup', handlePointerUp, { capture: true });
+      window.removeEventListener('pointercancel', handlePointerUp, { capture: true });
     }
   };
 
@@ -179,10 +187,11 @@ const InteractiveTick: React.FC<InteractiveTickProps> = ({
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
 
     if (pointers.current.size === 1) {
-      panSession.current = { id: e.pointerId, lastX: e.clientX, lastY: e.clientY };
+      panSession.current = { id: e.pointerId, lastX: e.clientX, lastY: e.clientY, totalDelta: 0 };
       // Use capture: true to ensure we get ALL events
       window.addEventListener('pointermove', handlePointerMove, { capture: true });
       window.addEventListener('pointerup', handlePointerUp, { capture: true });
+      window.addEventListener('pointercancel', handlePointerUp, { capture: true });
     } else if (pointers.current.size === 2) {
       panSession.current = null;
       const [p1, p2] = Array.from(pointers.current.values());

--- a/src/cartesian/Minimap.tsx
+++ b/src/cartesian/Minimap.tsx
@@ -313,7 +313,7 @@ function MinimapInternal(props: Props) {
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
-        onPointerLeave={handlePointerUp}
+        onPointerCancel={handlePointerUp}
       />
     </Layer>
   );

--- a/src/context/zoomPanContext.tsx
+++ b/src/context/zoomPanContext.tsx
@@ -968,22 +968,24 @@ export function ZoomPanContainer({ children, config }: { children: ReactNode; co
         return; 
       }
       
-      // Mobile edge scrolling - works even when tooltip is active
+      // Mobile edge scrolling - works even during a single-finger drag
       if (
-        !dragStart.current && // Don't conflict with main drag
         !selectStart.current && // Don't conflict with selection
         pointers.current.size === 1 && // Single finger only
         e.pointerType === 'touch' && // Touch only
         state.scaleX > 1.01 // Only when zoomed
       ) {
         const edgeThreshold = 60;
-        const panAmount = 8;
+        const distFromLeft = localX;
+        const distFromRight = width - localX;
         let panDeltaX = 0;
-        
-        if (localX < edgeThreshold && state.offsetX < 0) {
-          panDeltaX = panAmount;
-        } else if (localX > width - edgeThreshold && state.offsetX > width * (1 - state.scaleX)) {
-          panDeltaX = -panAmount;
+
+        if (distFromLeft < edgeThreshold && state.offsetX < 0) {
+          const ratio = 1 - distFromLeft / edgeThreshold;
+          panDeltaX = Math.ceil(8 + 12 * ratio);
+        } else if (distFromRight < edgeThreshold && state.offsetX > width * (1 - state.scaleX)) {
+          const ratio = 1 - distFromRight / edgeThreshold;
+          panDeltaX = -Math.ceil(8 + 12 * ratio);
         }
 
         if (panDeltaX !== 0) {
@@ -1162,7 +1164,9 @@ export function ZoomPanContainer({ children, config }: { children: ReactNode; co
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
-          onPointerLeave={cleanupInteractionState}
+          onPointerCancel={handlePointerUp}
+          // Avoid cancelling interactions when the pointer briefly leaves the chart area
+          // Cleanup will still happen on pointer up
           onBlur={cleanupInteractionState}
           onKeyDown={handleKeyDown}
           onFocus={handleOverlayFocus}
@@ -1175,7 +1179,6 @@ export function ZoomPanContainer({ children, config }: { children: ReactNode; co
             e.stopPropagation();
           }}
           onPointerUp={() => setIsInteracting(false)}
-          onPointerLeave={() => setIsInteracting(false)}
           >
             {minimapChildren}
           </g>


### PR DESCRIPTION
## Summary
- keep overlay and minimap dragging alive when a pointer cancel occurs
- add dynamic edge scrolling while dragging near chart edges

## Testing
- `npx eslint .` *(fails: 633 problems)*
- `npm test` *(fails: 17 failed test files)*

------
https://chatgpt.com/codex/tasks/task_e_6846893781c08323a4d656e866722c12